### PR TITLE
test: add missing module in tests (related to #18)

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -9,7 +9,7 @@ if __name__ == "__main__":
     failures = 0
     tests = 0
 
-    for module in [events, ephemerides]:
+    for module in [events, ephemerides, model]:
         (f, t) = doctest.testmod(module)
         failures += f
         tests += t


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Related issues | 
| Has BC-break   | no
| License        | CeCILL-C

Just adding a missing module to the tests