### PR TITLE
feat: use Skyfield-Data library instead of downloading needed files at first time

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,7 @@ coverage = "*"
 skyfield = ">=1.32.0,<2.0.0"
 numpy = ">=1.17.0,<2.0.0"
 python-dateutil = ">=2.8.0,<3.0.0"
+skyfield-data = ">=3.0.0,<4.0.0"
 
 [requires]
 python_version = "3"

--- a/kosmorrolib/core.py
+++ b/kosmorrolib/core.py
@@ -1,33 +1,24 @@
 #!/usr/bin/env python3
 
-from shutil import rmtree
-from pathlib import Path
-
 from skyfield.api import Loader
 from skyfield.timelib import Time
 from skyfield.nutationlib import iau2000b
 
-CACHE_FOLDER = str(Path.home()) + "/.kosmorro-cache"
+from skyfield_data import get_skyfield_data_path
 
-
-def get_loader():
-    return Loader(CACHE_FOLDER)
+LOADER = Loader(get_skyfield_data_path())
 
 
 def get_timescale():
-    return get_loader().timescale()
+    return LOADER.timescale()
 
 
 def get_skf_objects():
-    return get_loader()("de421.bsp")
+    return LOADER("de421.bsp")
 
 
 def get_iau2000b(time: Time):
     return iau2000b(time.tt)
-
-
-def clear_cache():
-    rmtree(CACHE_FOLDER)
 
 
 def flatten_list(the_list: list):


### PR DESCRIPTION
The folder created automatically at `~/.kosmorro-cache` is not needed
anymore and can be deleted safely.

| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Related issues | Fix #4
| Has BC-break   | no
| License        | CeCILL-C

<!--
    Replace this notice with a short README for your feature/bugfix.
-->

