### PR TITLE
feat(deprecation): deprecate `Event.get_description()` function

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,11 @@
-| Q              | A
-| -------------- | ---
-| Bug fix?       | yes/no
-| New feature?   | yes/no
-| Related issues | Fix #... <!-- prefix each issue number with "Fix #", if any -->
-| Has BC-break   | yes/no
-| License        | GNU AGPL-v3
+| Q                | A
+| --------------   | ---
+| Bug fix?         | yes/no
+| New feature?     | yes/no
+| Related issues   | Fix #... <!-- prefix each issue number with "Fix #" -->
+| Documentation PR | Kosmorrolib/libdoc#... <!-- if you implement a new feature, a PR in the documentation is required -->
+| Has BC-break     | yes/no
+| License          | GNU AGPL-v3
 
 <!--
     Replace this notice with a short README for your feature/bugfix.

--- a/kosmorrolib/core.py
+++ b/kosmorrolib/core.py
@@ -16,6 +16,7 @@
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from warnings import warn
 from skyfield.api import Loader
 from skyfield.timelib import Time
 from skyfield.nutationlib import iau2000b
@@ -48,3 +49,14 @@ def flatten_list(the_list: list):
         new_list.append(item)
 
     return new_list
+
+
+def deprecated(message):
+    def inner(decorated):
+        def f(*args, **kwargs):
+            warn(message, DeprecationWarning, stacklevel=2)
+            return decorated(*args, **kwargs)
+
+        return f
+
+    return inner

--- a/kosmorrolib/model.py
+++ b/kosmorrolib/model.py
@@ -25,7 +25,7 @@ import numpy
 from skyfield.api import Topos, Time, Angle
 from skyfield.vectorlib import VectorSum as SkfPlanet
 
-from .core import get_skf_objects, get_timescale
+from .core import get_skf_objects, get_timescale, deprecated
 from .enum import MoonPhaseType, EventType, ObjectIdentifier, ObjectType
 
 
@@ -240,17 +240,27 @@ class Event(Serializable):
             self.details,
         )
 
+    @deprecated(
+        "kosmorrolib.Event.get_description method is deprecated since version 1.1 "
+        "and will be removed in version 2.0. "
+        "It should be reimplemented it in your own code."
+    )
     def get_description(self, show_details: bool = True) -> str:
-        description = self.event_type.value % self._get_objects_name()
-        if show_details and self.details is not None:
-            description += " ({:s})".format(self.details)
+        """Return a textual description for the given details
+
+        *Deprecated* since version 1.1
+        """
+        description = f"Event of type {str(self.event_type)}"
+        if show_details and len(self.details) > 0:
+            details = ""
+            for key in self.details:
+                if details != "":
+                    details += ", "
+                details += f"{key}: {self.details[key]}"
+
+            description += f" ({details})"
+
         return description
-
-    def _get_objects_name(self):
-        if len(self.objects) == 1:
-            return self.objects[0].name
-
-        return tuple(object.name for object in self.objects)
 
     def serialize(self) -> dict:
         return {


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Has BC-break   | no
| License        | GNU AGPL-v3

Deprecating the `Event.get_description()` function.
It will be removed in v2.0. As a workaround, it should be reimplemented in downstream code.