### PR TITLE
fix: remove NumPy direct dependency

### DIFF
--- a/kosmorrolib/events.py
+++ b/kosmorrolib/events.py
@@ -23,10 +23,9 @@ from skyfield.timelib import Time
 from skyfield.searchlib import find_discrete, find_maxima, find_minima
 from skyfield.units import Angle
 from skyfield import almanac, eclipselib
-from numpy import pi
+from math import pi
 
 from kosmorrolib.model import (
-    Object,
     Event,
     Object,
     Star,

--- a/kosmorrolib/model.py
+++ b/kosmorrolib/model.py
@@ -19,8 +19,7 @@
 from abc import ABC, abstractmethod
 from typing import Union
 from datetime import datetime, timezone
-
-import numpy
+from math import asin
 
 from skyfield.api import Topos, Time, Angle
 from skyfield.vectorlib import VectorSum as SkfPlanet
@@ -180,7 +179,7 @@ class Object(Serializable):
             .radec()
         )
 
-        return Angle(radians=numpy.arcsin(self.radius / distance.km) * 2.0)
+        return Angle(radians=asin(self.radius / distance.km) * 2.0)
 
     def serialize(self) -> dict:
         """Serialize the given object

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
 python = ">=3.7,<3.11"
 skyfield = "^1.21"
 skyfield-data = "^3.0"
-numpy = "^1.17"
 python-dateutil = "^2.8"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Replacing the rare calls to Numpy's features with their equivalent in standard `math` library. This will simplify the maintenance of the library in the future.

Note that Numpy is still a dependency of Skyfield and its dependencies, so NumPy is actually still needed to run Kosmorrolib. But now, it is not used anymore here.

| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Related issues | 
| Has BC-break   | no
| License        | GNU AGPL-v3

<!--
    Replace this notice with a short README for your feature/bugfix.
-->

