### PR TITLE
feat(deprecation): deprecate the `kosmorrolib.__version__` module

### DIFF
--- a/kosmorrolib/__version__.py
+++ b/kosmorrolib/__version__.py
@@ -16,6 +16,22 @@
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from core import alert_deprecation
+from sys import version_info
+
+python_version = (version_info.major, version_info.minor)
+msg_python = (
+    '\nOn Python 3.7, you can also use the "importlib-metadata" package.'
+    if python_version == (3, 7)
+    else ""
+)
+
+alert_deprecation(
+    'Module "kosmorrolib.__version__" is deprecated since version 1.1. '
+    "Use the importlib.metadata module provided by Python 3.8+: "
+    "https://docs.python.org/3/library/importlib.metadata.html." + msg_python
+)
+
 __title__ = "kosmorrolib"
 __description__ = "A library to compute your ephemerides"
 __url__ = "http://kosmorro.space/lib"

--- a/kosmorrolib/core.py
+++ b/kosmorrolib/core.py
@@ -51,10 +51,19 @@ def flatten_list(the_list: list):
     return new_list
 
 
+def alert_deprecation(message):
+    """Show the given message as a deprecation warning.
+
+    >>> alert_deprecation("This is deprecated.")
+    sys:1: DeprecationWarning: This is deprecated.
+    """
+    warn(message, DeprecationWarning, stacklevel=2)
+
+
 def deprecated(message):
     def inner(decorated):
         def f(*args, **kwargs):
-            warn(message, DeprecationWarning, stacklevel=2)
+            alert_deprecation(message)
             return decorated(*args, **kwargs)
 
         return f


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes
| Related issues | 
| Has BC-break   | no
| License        | GNU AGPL-v3

<!--
    Replace this notice with a short README for your feature/bugfix.
-->

Since version 3.8, Python provides [a simpler way](https://docs.python.org/3/library/importlib.metadata.html) to get metadata about a package, making the `kosmorrolib__version__` module useless.
This also makes the versioning management quite simpler, since the codebase does not contain version number anymore.