### PR TITLE
build!: remove support for Python 3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.7,<3.11"
+python = ">=3.8,<3.11"
 skyfield = "^1.21"
 skyfield-data = ">=3,<5"
 python-dateutil = "^2.8"


### PR DESCRIPTION
NumPy does not support Python 3.7 anymore, and we will need to support Python 3.11 in #58, which is not possible without providing the last version of NumPy.