### PR TITLE
fix(dependencies): force using Numpy 2.0

### DIFF
--- a/.github/workflows/prchecks.yml
+++ b/.github/workflows/prchecks.yml
@@ -27,4 +27,4 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: 3.x
-    - uses: psf/black@20.8b1
+    - uses: psf/black@stable

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-11.0
+          - macos-latest
           - windows-latest
         python_version:
           - '3.8'
@@ -31,7 +31,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python_version }}
-        architecture: x64
 
     - name: Prepare environment
       run: |

--- a/kosmorrolib/events.py
+++ b/kosmorrolib/events.py
@@ -250,7 +250,7 @@ def _search_maximal_elongations(
                     EventType.MAXIMAL_ELONGATION,
                     [planet],
                     translate_to_timezone(time.utc_datetime(), timezone),
-                    details={"deg": elongation},
+                    details={"deg": float(elongation)},
                 )
             )
 
@@ -299,7 +299,7 @@ def _search_apogee(to_aster: Object, from_aster: Object = EARTH) -> callable:
                     EventType.APOGEE,
                     [to_aster],
                     translate_to_timezone(time.utc_datetime(), timezone),
-                    details={"distance_km": distances[i]},
+                    details={"distance_km": float(distances[i])},
                 )
             )
 
@@ -338,7 +338,7 @@ def _search_perigee(aster: Object, from_aster: Object = EARTH) -> callable:
                     EventType.PERIGEE,
                     [aster],
                     translate_to_timezone(time.utc_datetime(), timezone),
-                    details={"distance_km": distances[i]},
+                    details={"distance_km": float(distances[i])},
                 )
             )
 

--- a/kosmorrolib/model.py
+++ b/kosmorrolib/model.py
@@ -283,15 +283,17 @@ class AsterEphemerides(Serializable):
     def serialize(self) -> dict:
         return {
             "object": self.object.serialize(),
-            "rise_time": self.rise_time.isoformat()
-            if self.rise_time is not None
-            else None,
-            "culmination_time": self.culmination_time.isoformat()
-            if self.culmination_time is not None
-            else None,
-            "set_time": self.set_time.isoformat()
-            if self.set_time is not None
-            else None,
+            "rise_time": (
+                self.rise_time.isoformat() if self.rise_time is not None else None
+            ),
+            "culmination_time": (
+                self.culmination_time.isoformat()
+                if self.culmination_time is not None
+                else None
+            ),
+            "set_time": (
+                self.set_time.isoformat() if self.set_time is not None else None
+            ),
         }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,12 +20,12 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-skyfield = "^1.21"
+skyfield = "^1.49"
 numpy = [
     { version = "<1.25", python = "3.8.*" },
-    { version = "^1.25", python = ">=3.9,<3.13" },
+    { version = "^2.0", python = ">=3.9,<3.13" },
 ]
-skyfield-data = ">=3,<6"
+skyfield-data = "*"
 python-dateutil = "^2.8"
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ skyfield-data = "*"
 python-dateutil = "^2.8"
 
 [tool.poetry.group.dev.dependencies]
-black = "^23.1"
+black = ">23.1,<25.0"
 parameterized = "^0.9.0"
 coverage = "^6.1.2"
 coveralls = "^3.3.1"


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Has BC-break   | no
| License        | GNU AGPL-v3

Numpy 2.0 release has introduced some BC-breaks at Skyfield dependency level. Upgrading both Numpy and Skyfield minimal version to ensure they are fixed.